### PR TITLE
Compilation message with MPI extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,3 +2,15 @@ name = "TrixiBase"
 uuid = "9a0f1c46-06d5-4909-a5a3-ce25d3fa3284"
 authors = ["Michael Schlottke-Lakemper <michael@sloede.com>"]
 version = "0.1.0"
+
+[weakdeps]
+MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
+
+[extensions]
+TrixiBaseMPIExt = "MPI"
+
+[compat]
+julia = "1.8"
+
+[extras]
+MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 TrixiBaseMPIExt = "MPI"
 
 [compat]
+MPI = "0.20"
 julia = "1.8"
 
 [extras]

--- a/ext/TrixiBaseMPIExt.jl
+++ b/ext/TrixiBaseMPIExt.jl
@@ -10,7 +10,7 @@ import TrixiBase
 
 # This is a really working version - assuming the same
 # communication pattern etc. used in Trixi.jl.
-function TrixiBase.mpi_isparallel()
+function TrixiBase.mpi_isparallel(::Val{:MPIExt})
     if MPI.Initialized()
         return MPI.Comm_size(MPI.COMM_WORLD) > 1
     else

--- a/ext/TrixiBaseMPIExt.jl
+++ b/ext/TrixiBaseMPIExt.jl
@@ -1,0 +1,21 @@
+# Package extension for adding MPI-based features to TrixiBase.jl
+module TrixiBaseMPIExt
+__precompile__(false)
+
+# Load package extension code on Julia v1.9 and newer
+if isdefined(Base, :get_extension)
+    using MPI: MPI
+end
+import TrixiBase
+
+# This is a really working version - assuming the same
+# communication pattern etc. used in Trixi.jl.
+function TrixiBase.mpi_isparallel()
+    if MPI.Initialized()
+        return MPI.Comm_size(MPI.COMM_WORLD) > 1
+    else
+        return false
+    end
+end
+
+end

--- a/ext/TrixiBaseMPIExt.jl
+++ b/ext/TrixiBaseMPIExt.jl
@@ -1,6 +1,5 @@
 # Package extension for adding MPI-based features to TrixiBase.jl
 module TrixiBaseMPIExt
-__precompile__(false)
 
 # Load package extension code on Julia v1.9 and newer
 if isdefined(Base, :get_extension)

--- a/src/trixi_include.jl
+++ b/src/trixi_include.jl
@@ -39,6 +39,10 @@ function trixi_include(mod::Module, elixir::AbstractString; kwargs...)
         find_assignment(expr, key)
     end
 
+    # Print information on potential wait time only in non-parallel case
+    if !mpi_isparallel()
+        @info "You just called `trixi_include`. Julia may now compile the code, please be patient."
+    end
     Base.include(ex -> replace_assignments(insert_maxiters(ex); kwargs...), mod, elixir)
 end
 
@@ -143,3 +147,8 @@ function find_assignment(expr, destination)
 
     result
 end
+
+# This is just a dummy function. We only implement a real
+# version if MPI.jl is loaded to avoid letting TrixiBase.jl
+# depend explicitly on MPI.jl.
+mpi_isparallel() = false

--- a/src/trixi_include.jl
+++ b/src/trixi_include.jl
@@ -40,7 +40,7 @@ function trixi_include(mod::Module, elixir::AbstractString; kwargs...)
     end
 
     # Print information on potential wait time only in non-parallel case
-    if !mpi_isparallel(Val(:MPIExt))
+    if !mpi_isparallel(Val{:MPIExt}())
         @info "You just called `trixi_include`. Julia may now compile the code, please be patient."
     end
     Base.include(ex -> replace_assignments(insert_maxiters(ex); kwargs...), mod, elixir)

--- a/src/trixi_include.jl
+++ b/src/trixi_include.jl
@@ -40,7 +40,7 @@ function trixi_include(mod::Module, elixir::AbstractString; kwargs...)
     end
 
     # Print information on potential wait time only in non-parallel case
-    if !mpi_isparallel()
+    if !mpi_isparallel(Val(:MPIExt))
         @info "You just called `trixi_include`. Julia may now compile the code, please be patient."
     end
     Base.include(ex -> replace_assignments(insert_maxiters(ex); kwargs...), mod, elixir)
@@ -151,4 +151,4 @@ end
 # This is just a dummy function. We only implement a real
 # version if MPI.jl is loaded to avoid letting TrixiBase.jl
 # depend explicitly on MPI.jl.
-mpi_isparallel() = false
+mpi_isparallel(x) = false

--- a/test/dummy.jl
+++ b/test/dummy.jl
@@ -1,1 +1,0 @@
-println("Hello")

--- a/test/dummy.jl
+++ b/test/dummy.jl
@@ -1,0 +1,1 @@
+println("Hello")

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -20,9 +20,60 @@ macro trixi_testset(name, expr)
         using Test
         using TrixiBase
 
+        # We also include this file again to provide the definition of
+        # the other testing macros. This allows to use `@trixi_testset`
+        # in a nested fashion and also call `@test_nowarn_mod` from
+        # there.
+        include(@__FILE__)
+
         @testset verbose=true $name $expr
         end
 
         nothing
+    end
+end
+
+
+
+"""
+    @test_nowarn_mod expr
+
+Modified version of `@test_nowarn expr` that prints the content of `stderr` when
+it is not empty and ignores some common info statements printed in Trixi.jl
+uses.
+"""
+macro test_nowarn_mod(expr, additional_ignore_content = String[])
+    quote
+        let fname = tempname()
+            try
+                ret = open(fname, "w") do f
+                    redirect_stderr(f) do
+                        $(esc(expr))
+                    end
+                end
+                stderr_content = read(fname, String)
+                if !isempty(stderr_content)
+                    println("Content of `stderr`:\n", stderr_content)
+                end
+
+                # Patterns matching the following ones will be ignored. Additional patterns
+                # passed as arguments can also be regular expressions, so we just use the
+                # type `Any` for `ignore_content`.
+                ignore_content = Any[# We ignore our own compilation messages
+                                     "[ Info: You just called `trixi_include`. Julia may now compile the code, please be patient.\n",]
+                append!(ignore_content, $additional_ignore_content)
+                for pattern in ignore_content
+                    stderr_content = replace(stderr_content, pattern => "")
+                end
+
+                # We also ignore simple module redefinitions for convenience. Thus, we
+                # check whether every line of `stderr_content` is of the form of a
+                # module replacement warning.
+                @test occursin(r"^(WARNING: replacing module .+\.\n)*$", stderr_content)
+                ret
+            finally
+                rm(fname, force = true)
+            end
+        end
     end
 end

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -40,7 +40,7 @@ Modified version of `@test_nowarn expr` that prints the content of `stderr` when
 it is not empty and ignores some common info statements printed in Trixi.jl
 uses.
 """
-macro test_nowarn_mod(expr, additional_ignore_content=String[])
+macro test_nowarn_mod(expr, additional_ignore_content = String[])
     quote
         let fname = tempname()
             try
@@ -69,7 +69,7 @@ macro test_nowarn_mod(expr, additional_ignore_content=String[])
                 @test occursin(r"^(WARNING: replacing module .+\.\n)*$", stderr_content)
                 ret
             finally
-                rm(fname, force=true)
+                rm(fname, force = true)
             end
         end
     end

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -33,8 +33,6 @@ macro trixi_testset(name, expr)
     end
 end
 
-
-
 """
     @test_nowarn_mod expr
 
@@ -42,7 +40,7 @@ Modified version of `@test_nowarn expr` that prints the content of `stderr` when
 it is not empty and ignores some common info statements printed in Trixi.jl
 uses.
 """
-macro test_nowarn_mod(expr, additional_ignore_content = String[])
+macro test_nowarn_mod(expr, additional_ignore_content=String[])
     quote
         let fname = tempname()
             try
@@ -59,8 +57,7 @@ macro test_nowarn_mod(expr, additional_ignore_content = String[])
                 # Patterns matching the following ones will be ignored. Additional patterns
                 # passed as arguments can also be regular expressions, so we just use the
                 # type `Any` for `ignore_content`.
-                ignore_content = Any[# We ignore our own compilation messages
-                                     "[ Info: You just called `trixi_include`. Julia may now compile the code, please be patient.\n",]
+                ignore_content = Any["[ Info: You just called `trixi_include`. Julia may now compile the code, please be patient.\n"]
                 append!(ignore_content, $additional_ignore_content)
                 for pattern in ignore_content
                     stderr_content = replace(stderr_content, pattern => "")
@@ -72,7 +69,7 @@ macro test_nowarn_mod(expr, additional_ignore_content = String[])
                 @test occursin(r"^(WARNING: replacing module .+\.\n)*$", stderr_content)
                 ret
             finally
-                rm(fname, force = true)
+                rm(fname, force=true)
             end
         end
     end

--- a/test/trixi_include.jl
+++ b/test/trixi_include.jl
@@ -21,7 +21,7 @@
             @test x == 7
 
             # Verify default version (that includes in `Main`)
-            @test_nowarn trixi_include(filename, x = 11)
+            @test_nowarn_mod trixi_include(filename, x = 11)
             @test Main.x == 11
 
             @test_throws "assignment `y` not found in expression" trixi_include(@__MODULE__,
@@ -107,17 +107,17 @@
             # This is the default `maxiters` inserted by `trixi_include`
             @test x == 10^5
 
-            @test_nowarn trixi_include(@__MODULE__, filename2,
-                                       maxiters = 7)
+            @test_nowarn_mod trixi_include(@__MODULE__, filename2,
+                                           maxiters = 7)
             # Test that `maxiters` got overwritten
             @test x == 7
 
             # Verify that adding `maxiters` to `maxiters` results in exactly one of them
             # case 1) `maxiters` is *before* semicolon in included file
-            @test_nowarn trixi_include(@__MODULE__, filename3, maxiters = 11)
+            @test_nowarn_mod trixi_include(@__MODULE__, filename3, maxiters = 11)
             @test y == 11
             # case 2) `maxiters` is *after* semicolon in included file
-            @test_nowarn trixi_include(@__MODULE__, filename3, maxiters = 14)
+            @test_nowarn_mod trixi_include(@__MODULE__, filename3, maxiters = 14)
             @test y == 14
         finally
             rm(filename1, force = true)

--- a/test/trixi_include.jl
+++ b/test/trixi_include.jl
@@ -12,11 +12,11 @@
 
             # Use `@trixi_testset`, which wraps code in a temporary module, and call
             # `trixi_include` with `@__MODULE__` in order to isolate this test.
-            @test_nowarn trixi_include(@__MODULE__, filename)
+            @test_nowarn_mod trixi_include(@__MODULE__, filename)
             @test @isdefined x
             @test x == 4
 
-            @test_nowarn trixi_include(@__MODULE__, filename, x=7)
+            @test_nowarn_mod trixi_include(@__MODULE__, filename, x=7)
             @test x == 7
 
             @test_throws "assignment `y` not found in expression" trixi_include(@__MODULE__,
@@ -79,13 +79,13 @@
             # Use `@trixi_testset`, which wraps code in a temporary module, and call
             # `Base.include` and `trixi_include` with `@__MODULE__` in order to isolate this test.
             Base.include(@__MODULE__, filename1)
-            @test_nowarn trixi_include(@__MODULE__, filename2)
+            @test_nowarn_mod trixi_include(@__MODULE__, filename2)
             @test @isdefined x
             # This is the default `maxiters` inserted by `trixi_include`
             @test x == 10^5
 
-            @test_nowarn trixi_include(@__MODULE__, filename2,
-                                       maxiters=7)
+            @test_nowarn_mod trixi_include(@__MODULE__, filename2,
+                                           maxiters=7)
             # Test that `maxiters` got overwritten
             @test x == 7
         finally


### PR DESCRIPTION
I wanted to draft a version with a package extension for MPI so that we can still include the info message 

```
[ Info: You just called `trixi_include`. Julia may now compile the code, please be patient.
```

However, the first naive approach doesn't work nicely since we're not allowed to overwrite method definitions while precompiling. Thus, I needed to deactivate precompilation for the extension, resulting in the ugly messages

```julia
julia> using MPI, TrixiBase
[ Info: Precompiling TrixiBaseMPIExt [722ac391-ce67-58c0-be25-224aa07e4d5d]
[ Info: Skipping precompilation since __precompile__(false). Importing TrixiBaseMPIExt [722ac391-ce67-58c0-be25-224aa07e4d5d].

julia> trixi_include("test/dummy.jl")
[ Info: You just called `trixi_include`. Julia may now compile the code, please be patient.
Hello
```

We can not use something in `__init__` since that will be called before Trixi.jl is initialized - i.e., before MPI is initialized in general.