### PR TITLE
Replace jldoctest by example

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -28,7 +28,7 @@ jobs:
         #
         # julia  -e 'using Pkg; Pkg.add(PackageSpec(name = "JuliaFormatter", version = "0.13.0"))'
         run: |
-          julia  -e 'using Pkg; Pkg.add(PackageSpec(name = "JuliaFormatter"))'
+          julia  -e 'using Pkg; Pkg.add(PackageSpec(name = "JuliaFormatter", version="1.0.45"))'
           julia  -e 'using JuliaFormatter; format(".")'
       - name: Format check
         run: |

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -38,7 +38,8 @@ copy_file("LICENSE.md",
           "\n" => "\n> ", r"^" => "# License\n\n> ")
 
 # Make documentation
-makedocs(sitename = "TrixiBase.jl",
+makedocs(modules = [TrixiBase],
+         sitename = "TrixiBase.jl",
          # Provide additional formatting options
          format = Documenter.HTML(
                                   # Disable pretty URLs during manual testing

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -47,10 +47,12 @@ makedocs(modules = [TrixiBase],
                                   # Set canonical URL to GitHub pages URL
                                   canonical = "https://trixi-framework.github.io/TrixiBase.jl/stable"),
          # Explicitly specify documentation structure
-         pages = ["Home" => "index.md",
+         pages = [
+             "Home" => "index.md",
              "API reference" => "reference.md",
              "Authors" => "authors.md",
-             "License" => "license.md"])
+             "License" => "license.md",
+         ])
 
 deploydocs(;
            repo = "github.com/trixi-framework/TrixiBase.jl",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -48,9 +48,9 @@ makedocs(modules = [TrixiBase],
                                   canonical = "https://trixi-framework.github.io/TrixiBase.jl/stable"),
          # Explicitly specify documentation structure
          pages = ["Home" => "index.md",
-                  "API reference" => "reference.md",
-                  "Authors" => "authors.md",
-                  "License" => "license.md"])
+             "API reference" => "reference.md",
+             "Authors" => "authors.md",
+             "License" => "license.md"])
 
 deploydocs(;
            repo = "github.com/trixi-framework/TrixiBase.jl",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -47,12 +47,10 @@ makedocs(modules = [TrixiBase],
                                   # Set canonical URL to GitHub pages URL
                                   canonical = "https://trixi-framework.github.io/TrixiBase.jl/stable"),
          # Explicitly specify documentation structure
-         pages = [
-             "Home" => "index.md",
-             "API reference" => "reference.md",
-             "Authors" => "authors.md",
-             "License" => "license.md",
-         ])
+         pages = ["Home" => "index.md",
+                  "API reference" => "reference.md",
+                  "Authors" => "authors.md",
+                  "License" => "license.md"])
 
 deploydocs(;
            repo = "github.com/trixi-framework/TrixiBase.jl",

--- a/src/trixi_include.jl
+++ b/src/trixi_include.jl
@@ -18,7 +18,7 @@ for ODEs, see the "Miscellaneous" section of the
 
 # Examples
 
-```jldoctest
+```@example
 julia> redirect_stdout(devnull) do
          trixi_include(@__MODULE__, joinpath(examples_dir(), "tree_1d_dgsem", "elixir_advection_extended.jl"),
                        tspan=(0.0, 0.1))


### PR DESCRIPTION
This replaces the doctest of `trixi_include` by a usual example because the doctests fails.

closes https://github.com/trixi-framework/TrixiBase.jl/issues/12