### PR TITLE
Add a macro version of trixi_include to use the right module automatically

### DIFF
--- a/src/trixi_include.jl
+++ b/src/trixi_include.jl
@@ -62,6 +62,25 @@ function trixi_include(elixir::AbstractString; kwargs...)
 end
 
 """
+    @trixi_include(elixir::AbstractString; kwargs...)
+
+This is a convenience macro for [`trixi_include`](@ref) that evaluates the
+`trixi_include` function in the global scope of the current module.
+It is equivalent to calling `trixi_include` with the current module as the first argument.
+"""
+macro trixi_include(elixir, kwargs...)
+    foreach(kwargs) do kwarg
+        if !(kwarg isa Expr && kwarg.head === :(=))
+            throw(ArgumentError("`@trixi_include` only accepts keyword arguments, got: $kwarg"))
+        end
+        kwarg.head = :kw
+    end
+    esc(quote
+        $trixi_include($__module__, $(elixir); $(kwargs...))
+    end)
+end
+
+"""
     trixi_include_changeprecision(T, [mod::Module=Main,] elixir::AbstractString; kwargs...)
 
 `include` the elixir `elixir` and evaluate its content in the global scope of module `mod`.

--- a/test/trixi_include.jl
+++ b/test/trixi_include.jl
@@ -22,6 +22,10 @@
             @trixi_test_nowarn trixi_include(path, x = 11)
             @test Main.x == 11
 
+            # Verify that the macro version uses the right module
+            @trixi_include(path, x = 3)
+            @test x == 3
+
             @test_throws "assignment `y` not found in expression" trixi_include(@__MODULE__,
                                                                                 path,
                                                                                 y = 3)


### PR DESCRIPTION
I just ran into the footgun that in tests or in Documenter `trixi_include` uses the wrong module.
Using a macro we can query the calling module with `__module__` and allow for "prettier" usage.

I personally prefer macros for "magic" functionality like trixi_include

