### PR TITLE
Implement common parallel functionality for trixi-framework

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.9-DEV"
 
 [deps]
 ChangePrecision = "3cb15238-376d-56a3-8042-d33272777c9a"
+GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
@@ -17,6 +18,7 @@ TrixiBaseMPIExt = "MPI"
 
 [compat]
 ChangePrecision = "1.1.0"
+GPUArraysCore = "0.2.0"
 KernelAbstractions = "0.9.40"
 MPI = "0.20"
 Polyester = "0.7.19"

--- a/Project.toml
+++ b/Project.toml
@@ -5,20 +5,19 @@ version = "0.1.9-DEV"
 
 [deps]
 ChangePrecision = "3cb15238-376d-56a3-8042-d33272777c9a"
-GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
-Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [weakdeps]
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
+Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
 
 [extensions]
 TrixiBaseMPIExt = "MPI"
+TrixiBasePolyesterExt = "Polyester"
 
 [compat]
 ChangePrecision = "1.1.0"
-GPUArraysCore = "0.2.0"
 KernelAbstractions = "0.9.40"
 MPI = "0.20"
 Polyester = "0.7.19"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,8 @@ version = "0.1.9-DEV"
 
 [deps]
 ChangePrecision = "3cb15238-376d-56a3-8042-d33272777c9a"
+KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [weakdeps]
@@ -15,7 +17,9 @@ TrixiBaseMPIExt = "MPI"
 
 [compat]
 ChangePrecision = "1.1.0"
+KernelAbstractions = "0.9.40"
 MPI = "0.20"
+Polyester = "0.7.19"
 TimerOutputs = "0.5.25"
 julia = "1.10"
 

--- a/ext/TrixiBasePolyesterExt.jl
+++ b/ext/TrixiBasePolyesterExt.jl
@@ -1,0 +1,13 @@
+module TrixiBasePolyesterExt
+
+using TrixiBase: TrixiBase, PolyesterBackend
+using Polyester: Polyester
+
+# Use `Polyester.@batch`
+@inline function TrixiBase.parallel_foreach(f::F, iterator, ::PolyesterBackend) where F
+    Polyester.@batch for i in iterator
+        @inline f(i)
+    end
+end
+
+end # module TrixiBasePolyesterExt

--- a/ext/TrixiBasePolyesterExt.jl
+++ b/ext/TrixiBasePolyesterExt.jl
@@ -4,7 +4,7 @@ using TrixiBase: TrixiBase, PolyesterBackend
 using Polyester: Polyester
 
 # Use `Polyester.@batch`
-@inline function TrixiBase.parallel_foreach(f::F, iterator, ::PolyesterBackend) where F
+@inline function TrixiBase.parallel_foreach(f::F, iterator, ::PolyesterBackend) where {F}
     Polyester.@batch for i in iterator
         @inline f(i)
     end

--- a/src/TrixiBase.jl
+++ b/src/TrixiBase.jl
@@ -11,7 +11,7 @@ include("parallel.jl")
 export trixi_include, trixi_include_changeprecision
 export @trixi_timeit, timer, timeit_debug_enabled,
        disable_debug_timings, enable_debug_timings
-export @par, default_backend, parallel_foreach
+export @par, parallel_foreach
 
 function _precompile_manual_()
     @assert Base.precompile(Tuple{typeof(trixi_include), String})

--- a/src/TrixiBase.jl
+++ b/src/TrixiBase.jl
@@ -6,10 +6,12 @@ using TimerOutputs: TimerOutput, TimerOutputs
 include("mpi.jl")
 include("trixi_include.jl")
 include("trixi_timeit.jl")
+include("parallel.jl")
 
 export trixi_include, trixi_include_changeprecision
 export @trixi_timeit, timer, timeit_debug_enabled,
        disable_debug_timings, enable_debug_timings
+export @par, default_backend, parallel_foreach
 
 function _precompile_manual_()
     @assert Base.precompile(Tuple{typeof(trixi_include), String})

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -1,0 +1,176 @@
+# Return the `i`-th column of the array `A` as an `SVector`.
+@inline function extract_svector(A, ::Val{NDIMS}, i) where {NDIMS}
+    # Explicit bounds check, which can be removed by calling this function with `@inbounds`
+    @boundscheck checkbounds(A, NDIMS, i)
+
+    # Assume inbounds access now
+    return SVector(ntuple(@inline(dim->@inbounds A[dim, i]), NDIMS))
+end
+
+# When particles end up with coordinates so big that the cell coordinates
+# exceed the range of Int, then `floor(Int, i)` will fail with an InexactError.
+# In this case, we can just use typemax(Int), since we can assume that particles
+# that far away will not interact with anything, anyway.
+# This usually indicates an instability, but we don't want the simulation to crash,
+# since adaptive time integration methods may detect the instability and reject the
+# time step.
+# If we threw an error here, we would prevent the time integration method from
+# retrying with a smaller time step, and we would thus crash perfectly fine simulations.
+@inline function floor_to_int(i)
+    # `Base.floor(Int, i)` is defined as `trunc(Int, round(x, RoundDown))`
+    rounded = round(i, RoundDown)
+
+    # `Base.trunc(Int, x)` throws an `InexactError` in these cases, and otherwise
+    # returns `unsafe_trunc(Int, rounded)`.
+    if isnan(rounded) || rounded >= typemax(Int)
+        return typemax(Int)
+    elseif rounded <= typemin(Int)
+        return typemin(Int)
+    end
+
+    # After making sure that `rounded` is in the range of `Int`,
+    # we can safely call `unsafe_trunc`.
+    return unsafe_trunc(Int, rounded)
+end
+
+abstract type AbstractThreadingBackend end
+
+"""
+    SerialBackend()
+
+Pass as first argument to the [`@threaded`](@ref) macro to run the loop serially.
+"""
+struct SerialBackend <: AbstractThreadingBackend end
+
+"""
+    PolyesterBackend()
+
+Pass as first argument to the [`@threaded`](@ref) macro to make the loop multithreaded
+with `Polyester.@batch`.
+"""
+struct PolyesterBackend <: AbstractThreadingBackend end
+
+"""
+    ThreadsDynamicBackend()
+
+Pass as first argument to the [`@threaded`](@ref) macro to make the loop multithreaded
+with `Threads.@threads :dynamic`.
+"""
+struct ThreadsDynamicBackend <: AbstractThreadingBackend end
+
+"""
+    ThreadsStaticBackend()
+
+
+Pass as first argument to the [`@threaded`](@ref) macro to make the loop multithreaded
+with `Threads.@threads :static`.
+"""
+struct ThreadsStaticBackend <: AbstractThreadingBackend end
+
+const ParallelizationBackend = Union{AbstractThreadingBackend, KernelAbstractions.Backend}
+
+"""
+    default_backend(x)
+
+Select the recommended backend for an array `x`.
+This allows to write generic code that works for both CPU and GPU arrays.
+
+The default backend for CPU arrays is currently `PolyesterBackend()`.
+For GPU arrays, the respective `KernelAbstractions.Backend` is returned.
+"""
+@inline default_backend(::AbstractArray) = PolyesterBackend()
+@inline default_backend(x::AbstractGPUArray) = KernelAbstractions.get_backend(x)
+@inline default_backend(x::PermutedDimsArray) = default_backend(x.parent)
+
+"""
+    @threaded backend for ... end
+
+Run either a threaded CPU loop or launch a kernel on the GPU, depending on the `backend`.
+Semantically the same as `Threads.@threads` when iterating over a `AbstractUnitRange`
+but without guarantee that the underlying implementation uses `Threads.@threads`
+or works for more general `for` loops.
+
+Possible parallelization backends are:
+- [`SerialBackend`](@ref) to disable multithreading
+- [`PolyesterBackend`](@ref) to use `Polyester.@batch`
+- [`ThreadsDynamicBackend`](@ref) to use `Threads.@threads :dynamic`
+- [`ThreadsStaticBackend`](@ref) to use `Threads.@threads :static`
+- Any `KernelAbstractions.Backend` to execute the loop as a GPU kernel
+
+Use `default_backend(x)` to select the recommended backend for an array `x`.
+This allows to write generic code that works for both CPU and GPU arrays.
+
+!!! warning "Warning"
+    This macro does not necessarily work for general `for` loops. For example,
+    it does not necessarily support general iterables such as `eachline(filename)`.
+"""
+macro threaded(backend, expr)
+    # Reverse-engineer the for loop.
+    # `expr.args[1]` is the head of the for loop, like `i = eachindex(x)`.
+    # So, `expr.args[1].args[2]` is the iterator `eachindex(x)`
+    # and `expr.args[1].args[1]` is the loop variable `i`.
+    iterator = expr.args[1].args[2]
+    i = expr.args[1].args[1]
+    inner_loop = expr.args[2]
+
+    # Assemble the `for` loop again as a call to `parallel_foreach`, using `$i` to use the
+    # same loop variable as used in the for loop.
+    return esc(quote
+                   PointNeighbors.parallel_foreach($iterator, $backend) do $i
+                       $inner_loop
+                   end
+               end)
+end
+
+# Serial loop
+@inline function parallel_foreach(f, iterator, ::SerialBackend)
+    for i in iterator
+        @inline f(i)
+    end
+end
+
+# Use `Polyester.@batch`
+@inline function parallel_foreach(f, iterator, ::PolyesterBackend)
+    Polyester.@batch for i in iterator
+        @inline f(i)
+    end
+end
+
+# Use `Threads.@threads :dynamic`
+@inline function parallel_foreach(f, iterator, ::ThreadsDynamicBackend)
+    Threads.@threads :dynamic for i in iterator
+        @inline f(i)
+    end
+end
+
+# Use `Threads.@threads :static`
+@inline function parallel_foreach(f, iterator, ::ThreadsStaticBackend)
+    Threads.@threads :static for i in iterator
+        @inline f(i)
+    end
+end
+
+# On GPUs, execute `f` inside a GPU kernel with KernelAbstractions.jl
+@inline function parallel_foreach(f, iterator, backend::KernelAbstractions.Backend)
+    # On the GPU, we can only loop over `1:N`. Therefore, we loop over `1:length(iterator)`
+    # and index with `iterator[eachindex(iterator)[i]]`.
+    # Note that this only works with vector-like iterators that support arbitrary indexing.
+    indices = eachindex(iterator)
+    ndrange = length(indices)
+
+    # Skip empty loops
+    ndrange == 0 && return
+
+    # Call the generic kernel that is defined below, which only calls a function with
+    # the global GPU index.
+    generic_kernel(backend)(ndrange = ndrange) do i
+        @inbounds @inline f(iterator[indices[i]])
+    end
+
+    KernelAbstractions.synchronize(backend)
+end
+
+@kernel function generic_kernel(f)
+    i = @index(Global)
+    @inline f(i)
+end

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -1,7 +1,7 @@
-using KernelAbstractions
-using Polyester
-using Base.Threads
-using GPUArraysCore
+using KernelAbstractions: KernelAbstractions, @kernel, @index
+using Polyester: Polyester
+using Base.Threads: Threads
+using GPUArraysCore: AbstractGPUArray
 
 abstract type AbstractThreadingBackend end
 

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -1,7 +1,5 @@
-using KernelAbstractions: KernelAbstractions, @kernel, @index
-using Polyester: Polyester
+using KernelAbstractions: KernelAbstractions, @kernel, @index, @groupsize
 using Base.Threads: Threads
-using GPUArraysCore: AbstractGPUArray
 
 ##
 # Original approach formulated by @efaulhaber in PointNeighbors.jl
@@ -44,18 +42,6 @@ struct ThreadsStaticBackend <: AbstractThreadingBackend end
 const ParallelizationBackend = Union{AbstractThreadingBackend, KernelAbstractions.Backend}
 
 """
-    default_backend(x)
-
-Select the recommended backend for an array `x`.
-This allows to write generic code that works for both CPU and GPU arrays.
-
-The default backend for CPU arrays is currently `PolyesterBackend()`.
-For GPU arrays, the respective `KernelAbstractions.Backend` is returned.
-"""
-@inline default_backend(::AbstractArray) = PolyesterBackend()
-@inline default_backend(x::AbstractGPUArray) = KernelAbstractions.get_backend(x)
-
-"""
     @par backend for ... end
 
 Run either a threaded CPU loop or launch a kernel on the GPU, depending on the `backend`.
@@ -69,9 +55,6 @@ Possible parallelization backends are:
 - [`ThreadsDynamicBackend`](@ref) to use `Threads.@threads :dynamic`
 - [`ThreadsStaticBackend`](@ref) to use `Threads.@threads :static`
 - Any `KernelAbstractions.Backend` to execute the loop as a GPU kernel
-
-Use `default_backend(x)` to select the recommended backend for an array `x`.
-This allows to write generic code that works for both CPU and GPU arrays.
 
 !!! warning "Warning"
     This macro does not necessarily work for general `for` loops. For example,
@@ -105,13 +88,6 @@ end
     end
 end
 
-# Use `Polyester.@batch`
-@inline function parallel_foreach(f::F, iterator, ::PolyesterBackend) where F
-    Polyester.@batch for i in iterator
-        @inline f(i)
-    end
-end
-
 # Use `Threads.@threads :dynamic`
 @inline function parallel_foreach(f::F, iterator, ::ThreadsDynamicBackend) where F
     Threads.@threads :dynamic for i in iterator
@@ -131,7 +107,7 @@ end
     # On the GPU, we can only loop over `1:N`. Therefore, we loop over `1:length(iterator)`
     # and index with `iterator[eachindex(iterator)[i]]`.
     # Note that this only works with vector-like iterators that support arbitrary indexing.
-    indices = eachindex(iterator)
+    indices = eachindex(IndexLinear(), iterator)
     ndrange = length(indices)
 
     # Skip empty loops
@@ -139,15 +115,19 @@ end
 
     # Call the generic kernel that is defined below, which only calls a function with
     # the global GPU index.
-    generic_kernel(backend)(ndrange = ndrange) do i
-        @inbounds @inline f(iterator[indices[i]])
-    end
+    foreach_ka(backend)(f, iterator, indices, ndrange = ndrange)
 end
 
-# TODO: We could also use the slightly more optimized version from AcceleratedKernels
-@kernel function generic_kernel(f)
-    i = @index(Global)
-    @inline f(i)
+@kernel unsafe_indices=true function foreach_ka(f, iterator, indices)
+    # Calculate global index
+    N = @groupsize()[1]
+    iblock = @index(Group, Linear)
+    ithread = @index(Local, Linear)
+    i = ithread + (iblock - Int32(1)) * N
+
+    if i <= length(indices)
+        @inbounds @inline f(iterator[indices[i]])
+    end
 end
 
 # TODO: parallel_mapreduce

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -3,6 +3,10 @@ using Polyester: Polyester
 using Base.Threads: Threads
 using GPUArraysCore: AbstractGPUArray
 
+##
+# Original approach formulated by @efaulhaber in PointNeighbors.jl
+##
+
 abstract type AbstractThreadingBackend end
 
 """

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -63,16 +63,16 @@ Possible parallelization backends are:
 macro par(backend, expr)
     expr.head != :for && error("@par can only be used with for loops")
     iter = expr.args[1]
-    iter.head != :(=) && error("@par can only be used with for loops of the form `for i in iterator`")
+    iter.head != :(=) &&
+        error("@par can only be used with for loops of the form `for i in iterator`")
 
     body = expr.args[2]
     induction_var = iter.args[1]
     iterator = iter.args[2]
 
-
     # Assemble the `for` loop again as a call to `parallel_foreach`, using `$induction_var` to use the
     # same loop variable as used in the for loop.
-    expr = quote 
+    expr = quote
         $parallel_foreach($iterator, $backend) do $induction_var
             $body
         end
@@ -82,28 +82,29 @@ macro par(backend, expr)
 end
 
 # Serial loop
-@inline function parallel_foreach(f::F, iterator, ::SerialBackend) where F
+@inline function parallel_foreach(f::F, iterator, ::SerialBackend) where {F}
     for i in iterator
         @inline f(i)
     end
 end
 
 # Use `Threads.@threads :dynamic`
-@inline function parallel_foreach(f::F, iterator, ::ThreadsDynamicBackend) where F
+@inline function parallel_foreach(f::F, iterator, ::ThreadsDynamicBackend) where {F}
     Threads.@threads :dynamic for i in iterator
         @inline f(i)
     end
 end
 
 # Use `Threads.@threads :static`
-@inline function parallel_foreach(f::F, iterator, ::ThreadsStaticBackend) where F
+@inline function parallel_foreach(f::F, iterator, ::ThreadsStaticBackend) where {F}
     Threads.@threads :static for i in iterator
         @inline f(i)
     end
 end
 
 # On GPUs, execute `f` inside a GPU kernel with KernelAbstractions.jl
-@inline function parallel_foreach(f::F, iterator, backend::KernelAbstractions.Backend) where F
+@inline function parallel_foreach(f::F, iterator,
+                                  backend::KernelAbstractions.Backend) where {F}
     # On the GPU, we can only loop over `1:N`. Therefore, we loop over `1:length(iterator)`
     # and index with `iterator[eachindex(iterator)[i]]`.
     # Note that this only works with vector-like iterators that support arbitrary indexing.

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -1,6 +1,7 @@
 using KernelAbstractions
 using Polyester
 using Base.Threads
+using GPUArraysCore
 
 abstract type AbstractThreadingBackend end
 
@@ -144,3 +145,5 @@ end
     i = @index(Global)
     @inline f(i)
 end
+
+# TODO: parallel_mapreduce

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -1,37 +1,6 @@
-# Return the `i`-th column of the array `A` as an `SVector`.
-@inline function extract_svector(A, ::Val{NDIMS}, i) where {NDIMS}
-    # Explicit bounds check, which can be removed by calling this function with `@inbounds`
-    @boundscheck checkbounds(A, NDIMS, i)
-
-    # Assume inbounds access now
-    return SVector(ntuple(@inline(dim->@inbounds A[dim, i]), NDIMS))
-end
-
-# When particles end up with coordinates so big that the cell coordinates
-# exceed the range of Int, then `floor(Int, i)` will fail with an InexactError.
-# In this case, we can just use typemax(Int), since we can assume that particles
-# that far away will not interact with anything, anyway.
-# This usually indicates an instability, but we don't want the simulation to crash,
-# since adaptive time integration methods may detect the instability and reject the
-# time step.
-# If we threw an error here, we would prevent the time integration method from
-# retrying with a smaller time step, and we would thus crash perfectly fine simulations.
-@inline function floor_to_int(i)
-    # `Base.floor(Int, i)` is defined as `trunc(Int, round(x, RoundDown))`
-    rounded = round(i, RoundDown)
-
-    # `Base.trunc(Int, x)` throws an `InexactError` in these cases, and otherwise
-    # returns `unsafe_trunc(Int, rounded)`.
-    if isnan(rounded) || rounded >= typemax(Int)
-        return typemax(Int)
-    elseif rounded <= typemin(Int)
-        return typemin(Int)
-    end
-
-    # After making sure that `rounded` is in the range of `Int`,
-    # we can safely call `unsafe_trunc`.
-    return unsafe_trunc(Int, rounded)
-end
+using KernelAbstractions
+using Polyester
+using Base.Threads
 
 abstract type AbstractThreadingBackend end
 
@@ -80,10 +49,9 @@ For GPU arrays, the respective `KernelAbstractions.Backend` is returned.
 """
 @inline default_backend(::AbstractArray) = PolyesterBackend()
 @inline default_backend(x::AbstractGPUArray) = KernelAbstractions.get_backend(x)
-@inline default_backend(x::PermutedDimsArray) = default_backend(x.parent)
 
 """
-    @threaded backend for ... end
+    @par backend for ... end
 
 Run either a threaded CPU loop or launch a kernel on the GPU, depending on the `backend`.
 Semantically the same as `Threads.@threads` when iterating over a `AbstractUnitRange`
@@ -104,54 +72,57 @@ This allows to write generic code that works for both CPU and GPU arrays.
     This macro does not necessarily work for general `for` loops. For example,
     it does not necessarily support general iterables such as `eachline(filename)`.
 """
-macro threaded(backend, expr)
-    # Reverse-engineer the for loop.
-    # `expr.args[1]` is the head of the for loop, like `i = eachindex(x)`.
-    # So, `expr.args[1].args[2]` is the iterator `eachindex(x)`
-    # and `expr.args[1].args[1]` is the loop variable `i`.
-    iterator = expr.args[1].args[2]
-    i = expr.args[1].args[1]
-    inner_loop = expr.args[2]
+macro par(backend, expr)
+    expr.head != :for && error("@par can only be used with for loops")
+    iter = expr.args[1]
+    iter.head != :(=) && error("@par can only be used with for loops of the form `for i in iterator`")
 
-    # Assemble the `for` loop again as a call to `parallel_foreach`, using `$i` to use the
+    body = expr.args[2]
+    induction_var = iter.args[1]
+    iterator = iter.args[2]
+
+
+    # Assemble the `for` loop again as a call to `parallel_foreach`, using `$induction_var` to use the
     # same loop variable as used in the for loop.
-    return esc(quote
-                   PointNeighbors.parallel_foreach($iterator, $backend) do $i
-                       $inner_loop
-                   end
-               end)
+    expr = quote 
+        $parallel_foreach($iterator, $backend) do $induction_var
+            $body
+        end
+    end
+
+    return esc(expr)
 end
 
 # Serial loop
-@inline function parallel_foreach(f, iterator, ::SerialBackend)
+@inline function parallel_foreach(f::F, iterator, ::SerialBackend) where F
     for i in iterator
         @inline f(i)
     end
 end
 
 # Use `Polyester.@batch`
-@inline function parallel_foreach(f, iterator, ::PolyesterBackend)
+@inline function parallel_foreach(f::F, iterator, ::PolyesterBackend) where F
     Polyester.@batch for i in iterator
         @inline f(i)
     end
 end
 
 # Use `Threads.@threads :dynamic`
-@inline function parallel_foreach(f, iterator, ::ThreadsDynamicBackend)
+@inline function parallel_foreach(f::F, iterator, ::ThreadsDynamicBackend) where F
     Threads.@threads :dynamic for i in iterator
         @inline f(i)
     end
 end
 
 # Use `Threads.@threads :static`
-@inline function parallel_foreach(f, iterator, ::ThreadsStaticBackend)
+@inline function parallel_foreach(f::F, iterator, ::ThreadsStaticBackend) where F
     Threads.@threads :static for i in iterator
         @inline f(i)
     end
 end
 
 # On GPUs, execute `f` inside a GPU kernel with KernelAbstractions.jl
-@inline function parallel_foreach(f, iterator, backend::KernelAbstractions.Backend)
+@inline function parallel_foreach(f::F, iterator, backend::KernelAbstractions.Backend) where F
     # On the GPU, we can only loop over `1:N`. Therefore, we loop over `1:length(iterator)`
     # and index with `iterator[eachindex(iterator)[i]]`.
     # Note that this only works with vector-like iterators that support arbitrary indexing.
@@ -166,10 +137,9 @@ end
     generic_kernel(backend)(ndrange = ndrange) do i
         @inbounds @inline f(iterator[indices[i]])
     end
-
-    KernelAbstractions.synchronize(backend)
 end
 
+# TODO: We could also use the slightly more optimized version from AcceleratedKernels
 @kernel function generic_kernel(f)
     i = @index(Global)
     @inline f(i)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
+KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TrixiTest = "0a316866-cbd0-4425-8bcb-08103b2c1f26"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -3,6 +3,7 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
+Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TrixiTest = "0a316866-cbd0-4425-8bcb-08103b2c1f26"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,5 +6,5 @@ include("test_util.jl")
     run(`$(mpiexec()) -n 2 $(Base.julia_cmd()) --threads=1 $(abspath("test_mpi.jl"))`)
     include("trixi_include.jl")
     include("test_timers.jl")
-    run(`$(Base.julia_cmd()) --threads=2 $(abspath("test_parallel.jl"))`)
+    include("test_parallel.jl")
 end;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,4 +6,5 @@ include("test_util.jl")
     run(`$(mpiexec()) -n 2 $(Base.julia_cmd()) --threads=1 $(abspath("test_mpi.jl"))`)
     include("trixi_include.jl")
     include("test_timers.jl")
+    run(`$(Base.julia_cmd()) --threads=2 $(abspath("test_parallel.jl"))`)
 end;

--- a/test/test_parallel.jl
+++ b/test/test_parallel.jl
@@ -1,0 +1,29 @@
+include("test_util.jl")
+
+import KernelAbstractions: CPU
+
+@testset verbose=true "default_backend functions" begin
+    @test TrixiBase.default_backend([1, 2, 3]) isa TrixiBase.PolyesterBackend
+end
+
+@testset verbose=true "@par macro" begin
+    @par TrixiBase.SerialBackend() for i in 1:10
+        @test i in 1:10
+    end
+
+    @par TrixiBase.ThreadsDynamicBackend() for i in 1:10
+        @test i in 1:10
+    end
+
+    @par TrixiBase.ThreadsStaticBackend() for i in 1:10
+        @test i in 1:10
+    end
+
+    @par TrixiBase.PolyesterBackend() for i in 1:10
+        @test i in 1:10
+    end
+
+    @par CPU() for i in 1:10
+        @test i in 1:10
+    end
+end

--- a/test/test_parallel.jl
+++ b/test/test_parallel.jl
@@ -3,7 +3,7 @@ include("test_util.jl")
 import KernelAbstractions: CPU
 
 @testset verbose=true "default_backend functions" begin
-    @test TrixiBase.default_backend([1, 2, 3]) isa TrixiBase.PolyesterBackend
+    @test default_backend([1, 2, 3]) isa TrixiBase.PolyesterBackend
 end
 
 @testset verbose=true "@par macro" begin

--- a/test/test_parallel.jl
+++ b/test/test_parallel.jl
@@ -1,10 +1,7 @@
 include("test_util.jl")
 
 import KernelAbstractions: CPU
-
-@testset verbose=true "default_backend functions" begin
-    @test default_backend([1, 2, 3]) isa TrixiBase.PolyesterBackend
-end
+using Polyester
 
 @testset verbose=true "@par macro" begin
     @par TrixiBase.SerialBackend() for i in 1:10


### PR DESCRIPTION
Heavily based on @efaulhaber infrastructure in PointNeighbors.jl

During Trudi @efaulhaber, @benegee and I were discussing how to reduce the code duplication currently in https://github.com/trixi-framework/Trixi.jl/pull/2590

Currently we have a lot of fairly simple kernel like:

```
function calc_volume_integral!(backend::Backend, du, u, mesh,
                               have_nonconservative_terms, equations,
                               volume_integral, dg::DGSEM, cache)
    nelements(dg, cache) == 0 && return nothing
    kernel! = volume_integral_KAkernel!(backend)
    kernel_cache = kernel_filter_cache(cache)
    kernel!(du, u, typeof(mesh), have_nonconservative_terms, equations,
            volume_integral, dg, kernel_cache,
            ndrange = nelements(dg, cache))
    return nothing
end

@kernel function volume_integral_KAkernel!(du, u, meshT,
                                           have_nonconservative_terms, equations,
                                           volume_integral, dg::DGSEM, cache)
    element = @index(Global)
    volume_integral_kernel!(du, u, element, meshT, have_nonconservative_terms,
                            equations, volume_integral, dg, cache)
end
```

With the old code looking more like

```

function calc_volume_integral!(backend::Nothing, du, u, mesh,
                               have_nonconservative_terms, equations,
                               volume_integral, dg::DGSEM, cache)
    @threaded for element in eachelement(dg, cache)
        volume_integral_kernel!(du, u, element, typeof(mesh),
                                have_nonconservative_terms, equations,
                                volume_integral, dg, cache)
    end

    return nothing
end
```

@efaulhaber has been using a macro of this style (and a clear evolution of Trixi own `@threaded`) to great effect,
so it would make sense to have one shared definition.

## Considerations:

1. Is this the right place for the code to live? Or is TrixiBase to "low" and does not want the additional dependencies.
2. I would like to have the Polyester code being an extension, but the `default_backend` definition makes that non-sensical

AcceleratedKernels.jl has a very similar definition in `foreachindex`, but also has the parallel mapreduce we would need in Trixi.

https://github.com/JuliaGPU/AcceleratedKernels.jl/blob/e641c281f9373825f9852fb84457c608b6074586/src/foreachindex.jl#L122

I could see this definition living in KernelAbstractions (but it would then kinda conflict with AcceleratedKernels, and the Polyester dependency is a no-go). 

Putting this up as a draft so that we can mull about it.

